### PR TITLE
Include users as minipool operators if they also have AVAX Validating High Water

### DIFF
--- a/contracts/pandasia.sol
+++ b/contracts/pandasia.sol
@@ -13,6 +13,8 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 
 interface Staking {
   function getLastRewardsCycleCompleted(address stakerAddr) external view returns (uint256);
+
+  function getAVAXValidatingHighWater(address stakerAddr) external view returns (uint256);
 }
 
 interface Storage {
@@ -252,7 +254,7 @@ contract Pandasia is OwnableUpgradeable, AccessControlUpgradeable {
   function isMinipoolOperator(address addr) public view returns (bool) {
     bytes32 key = keccak256(abi.encodePacked("contract.address", "Staking"));
     address stakingContract = Storage(storageContract).getAddress(key);
-    return Staking(stakingContract).getLastRewardsCycleCompleted(addr) > 0;
+    return Staking(stakingContract).getLastRewardsCycleCompleted(addr) > 0 || Staking(stakingContract).getAVAXValidatingHighWater(addr) > 0;
   }
 
   /**************************************************************************************************************************************/

--- a/test/unit/airdrop.t.sol
+++ b/test/unit/airdrop.t.sol
@@ -64,6 +64,7 @@ contract AirdropTest is Test {
 
     stakingContract = new StakingMock();
     stakingContract.setLastRewardsCycleCompleted(minipoolOperator, 1);
+    stakingContract.setAVAXValidatingHighWater(minipoolOperator, 1000 ether);
 
     storageContract = new StorageMock();
     storageContract.setAddress(keccak256(abi.encodePacked("contract.address", "Staking")), address(stakingContract));
@@ -386,6 +387,18 @@ contract AirdropTest is Test {
 
     hasClaimed = pandasia.hasClaimed(id, validator);
     assertTrue(hasClaimed);
+  }
+
+  function testIsMinipoolOperator() public {
+    address onlyCycle = getActor("onlyCycle");
+    address onlyHighWater = getActor("onlyHighWater");
+
+    stakingContract.setLastRewardsCycleCompleted(onlyCycle, 1);
+    stakingContract.setAVAXValidatingHighWater(onlyHighWater, 1000 ether);
+
+    assertTrue(pandasia.isMinipoolOperator(minipoolOperator));
+    assertTrue(pandasia.isMinipoolOperator(onlyCycle));
+    assertTrue(pandasia.isMinipoolOperator(onlyHighWater));
   }
 
   /**************************************************************************************************************************************/

--- a/test/unit/mocks/StakingMock.sol
+++ b/test/unit/mocks/StakingMock.sol
@@ -4,19 +4,33 @@ pragma solidity ^0.8.19;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract StakingMock {
-  // Mock this from GoGoPool
+  // Mock these methods from GoGoPool
   // function getLastRewardsCycleCompleted(address stakerAddr) public view returns (uint256) {
   // 	int256 stakerIndex = getIndexOf(stakerAddr);
   // 	return getUint(keccak256(abi.encodePacked("staker.item", stakerIndex, ".lastRewardsCycleCompleted")));
   // }
 
-  mapping(address => uint256) private mockData;
+  // function getAVAXValidatingHighWater(address stakerAddr) public view returns (uint256) {
+  // 	int256 stakerIndex = getIndexOf(stakerAddr);
+  // 	return getUint(keccak256(abi.encodePacked("staker.item", stakerIndex, ".avaxValidatingHighWater")));
+  // }
+
+  mapping(address => uint256) private mockCycle;
+  mapping(address => uint256) private mockHighWater;
 
   function setLastRewardsCycleCompleted(address stakerAddr, uint256 num) public {
-    mockData[stakerAddr] = num;
+    mockCycle[stakerAddr] = num;
   }
 
   function getLastRewardsCycleCompleted(address stakerAddr) public view returns (uint256) {
-    return mockData[stakerAddr];
+    return mockCycle[stakerAddr];
+  }
+
+  function setAVAXValidatingHighWater(address stakerAddr, uint256 num) public {
+    mockHighWater[stakerAddr] = num;
+  }
+
+  function getAVAXValidatingHighWater(address stakerAddr) public view returns (uint256) {
+    return mockHighWater[stakerAddr];
   }
 }


### PR DESCRIPTION
New minipool operators that haven't completed a cycle yet were being excluded from Pandasia even though they were actively running minipools. 

This additional check should include historical and current operators. 